### PR TITLE
Add the notification banner 

### DIFF
--- a/app/main/views/auth.py
+++ b/app/main/views/auth.py
@@ -18,6 +18,7 @@ from dmutils.forms.errors import (
 )
 from dmutils.user import User
 from dmutils.email.helpers import hash_string
+from dmutils.dmp_so_status import are_new_frameworks_live
 
 from .. import main
 from ..forms.auth_forms import LoginForm
@@ -43,7 +44,8 @@ def render_login():
         "auth/login.html",
         form=form,
         errors=errors,
-        next=next_url), 200
+        next=next_url,
+        are_new_frameworks_live=are_new_frameworks_live(request.args)), 200
 
 
 @main.route('/login', methods=["POST"])
@@ -73,7 +75,8 @@ def process_login():
                 form=form,
                 errors=errors,
                 error_summary_description_text=NO_ACCOUNT_MESSAGE,
-                next=next_url), 403
+                next=next_url,
+                are_new_frameworks_live=are_new_frameworks_live(request.args)), 403
 
         user = User.from_json(user_json)
 
@@ -88,7 +91,8 @@ def process_login():
             "auth/login.html",
             form=form,
             errors=errors,
-            next=next_url), 400
+            next=next_url,
+            are_new_frameworks_live=are_new_frameworks_live(request.args)), 400
 
 
 # We allow logging out via GET request so that we can have a simple link in the

--- a/app/templates/_base_page.html
+++ b/app/templates/_base_page.html
@@ -16,6 +16,7 @@
 {% from "digitalmarketplace/components/header/macro.njk" import dmHeader %}
 {% from "digitalmarketplace/components/footer/macro.njk" import dmFooter %}
 {% from "digitalmarketplace/components/alert/macro.njk" import dmAlert %}
+{% from "digitalmarketplace/components/new-framework-banner/macro.njk" import dmNewFrameworkBanner %}
 
 {% set assetPath = '/user/static' %}
 

--- a/app/templates/auth/login.html
+++ b/app/templates/auth/login.html
@@ -17,6 +17,14 @@
 {% endblock %}
 
 {% block mainContent %}
+  {% if are_new_frameworks_live %}
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        {{ dmNewFrameworkBanner() }}
+      </div>
+    </div>
+  {% endif %}
+
   <h1 class="govuk-heading-xl">Log in to the Digital Marketplace</h1>
 
   <form action="{{ url_for('.process_login', next=next) }}" method="POST" novalidate>

--- a/tests/main/views/test_auth.py
+++ b/tests/main/views/test_auth.py
@@ -11,6 +11,8 @@ from app.main.forms.auth_forms import (
 )
 from app.main.views.auth import NO_ACCOUNT_MESSAGE
 
+from freezegun import freeze_time
+
 
 # subset of WCAG 2.1 input purposes
 # https://www.w3.org/TR/WCAG21/#input-purposes
@@ -39,6 +41,36 @@ class TestLogin(BaseApplicationTest):
         res = self.client.get("/user/login")
         assert res.status_code == 200
         assert "Log in to the Digital Marketplace" in res.get_data(as_text=True)
+
+    @freeze_time('2022-01-04')
+    def test_should_not_show_banner_if_before_go_live_date(self):
+        res = self.client.get("/user/login")
+        assert res.status_code == 200
+        assert "Important supplier information" not in res.get_data(as_text=True)
+
+    @freeze_time('2022-01-14')
+    def test_should_show_banner_if_on_go_live_date(self):
+        res = self.client.get("/user/login")
+        assert res.status_code == 200
+        assert "Important supplier information" in res.get_data(as_text=True)
+
+    @freeze_time('2022-01-15')
+    def test_should_show_banner_if_after_go_live_date(self):
+        res = self.client.get("/user/login")
+        assert res.status_code == 200
+        assert "Important supplier information" in res.get_data(as_text=True)
+
+    @freeze_time('2022-01-04')
+    def test_should_show_banner_if_before_date_and_go_live_param(self):
+        res = self.client.get("/user/login?show_dmp_so_banner=true")
+        assert res.status_code == 200
+        assert "Important supplier information" in res.get_data(as_text=True)
+
+    @freeze_time('2022-01-04')
+    def test_should_not_show_banner_if_before_date_and_not_go_live_param(self):
+        res = self.client.get("/user/login?show_dos6_live=true")
+        assert res.status_code == 200
+        assert "Important supplier information" not in res.get_data(as_text=True)
 
     def test_should_redirect_to_supplier_dashboard_on_supplier_login(self):
         res = self.client.post("/user/login", data={
@@ -223,6 +255,16 @@ class TestLogin(BaseApplicationTest):
 
         assert response.status_code == 403
 
+    @freeze_time('2022-02-24')
+    def test_should_show_banner_if_after_go_live_date_when_invalid_403(self):
+        self.data_api_client.authenticate_user.return_value = None
+        res = self.client.post("/user/login", data={
+            'email_address': 'valid@email.com',
+            'password': '1234567890'
+        })
+        assert res.status_code == 403
+        assert "Important supplier information" in res.get_data(as_text=True)
+
     def test_should_be_validation_error_if_no_email_or_password(self):
         res = self.client.post("/user/login", data={})
         content = self.strip_all_whitespace(res.get_data(as_text=True))
@@ -238,6 +280,12 @@ class TestLogin(BaseApplicationTest):
         content = self.strip_all_whitespace(res.get_data(as_text=True))
         assert res.status_code == 400
         assert self.strip_all_whitespace(EMAIL_INVALID_ERROR_MESSAGE) in content
+
+    @freeze_time('2022-01-24')
+    def test_should_show_banner_if_after_go_live_date_when_invalid_400(self):
+        res = self.client.post("/user/login", data={})
+        assert res.status_code == 400
+        assert "Important supplier information" in res.get_data(as_text=True)
 
 
 class TestLoginFormIsAccessible(BaseApplicationTest):


### PR DESCRIPTION
- Add logic for the banner
- Add tests for the banner


This is from the ticket [OST-134](https://crowncommercialservice.atlassian.net/browse/OST-134) (3/5)

This is a screenshot of what the login page would look like:
![localhost_user_login_show_dmp_so_banner=true (3)](https://user-images.githubusercontent.com/58297459/148528106-17bce128-f33d-4495-94f5-2ae4185e6560.png)


I've set it up so the the banner will be shown on and after the DOS6 'Go Live' date (2022-01-14).
In order to see the banner before the 'Go Live' date, a user can add the param `show_dmp_so_banner=true` to the URL.
So for preview, the url to view the banner now would be: https://www.preview.marketplace.team/user/login?show_dmp_so_banner=true
